### PR TITLE
Update makefiles to remove opengl deprecated warnings from mac builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ LINK_LIBS += -ldl
 
 ifeq ($(OSSPEC), MacOS)
     LINK_LIBS += -framework AppKit
+    CXXFLAGS += -Wno-deprecated -Wno-deprecated-declarations
 else
     CXXFLAGS += -D_GNU_SOURCE
     LINK_LIBS += -lrt -L/usr/X11R6/lib -lX11 -lXi -lXmu

--- a/osenv/Makefile
+++ b/osenv/Makefile
@@ -7,10 +7,10 @@ LIBDIR := $(shell ./bin/osenv-config --libdir)
 HEADERS := $(wildcard *.hh)
 ifeq ($(OSSPEC), MacOS)
     OBJECTS := $(foreach obj, $(patsubst %.mm, %.o, $(wildcard *.mm)), $(OBJDIR)/$(obj))
+    CXXFLAGS += -Wno-deprecated -Wno-deprecated-declarations
 else
     OBJECTS := $(foreach obj, $(patsubst %.cc, %.o, $(wildcard *.cc)), $(OBJDIR)/$(obj))
 endif
-
 $(LIBDIR)/libosenv.a: $(OBJECTS)
 	mkdir -p $(LIBDIR)
 	$(AR) $(ARFLAGS) $@ $^

--- a/packages/TaraDraw/mac/Makefile
+++ b/packages/TaraDraw/mac/Makefile
@@ -6,7 +6,7 @@ LIBDIR := $(shell ../bin/TaraDraw-config --libdir)
 HEADERS := $(wildcard *.hh)
 OBJECTS := $(foreach obj, $(patsubst %.mm, %.o, $(wildcard *.mm)), $(OBJDIR)/$(obj))
 
-CXXFLAGS += -Wall -Wextra  $(shell ../bin/TaraDraw-config --cflags_internal)
+CXXFLAGS += -Wall -Wextra  $(shell ../bin/TaraDraw-config --cflags_internal) -Wno-deprecated -Wno-deprecated-declarations
 
 $(LIBDIR)/libTD.a: $(OBJECTS)
 	mkdir -p $(LIBDIR)


### PR DESCRIPTION
Ignores deprecated warnings from Apple about OpenGL