### PR TITLE
add dynamic file pixel stream protocol

### DIFF
--- a/packages/PixelStream/PixelStream.hh
+++ b/packages/PixelStream/PixelStream.hh
@@ -5,5 +5,6 @@
 #include "PixelStreamMjpeg.hh"
 #include "PixelStreamTcp.hh"
 #include "PixelStreamVsm.hh"
+#include "PixelStreamDynamicFile.hh"
 
 #endif

--- a/packages/PixelStream/PixelStreamData.cc
+++ b/packages/PixelStream/PixelStreamData.cc
@@ -4,6 +4,7 @@
 #include "PixelStreamMjpeg.hh"
 #include "PixelStreamTcp.hh"
 #include "PixelStreamVsm.hh"
+#include "PixelStreamDynamicFile.hh"
 
 PixelStreamData::PixelStreamData()
 :
@@ -28,6 +29,9 @@ bool PixelStreamData::operator == (const PixelStreamData &that)
         {
         case PixelStreamFileProtocol:
             return (*(PixelStreamFile *)this == *(PixelStreamFile *)&that);
+            break;
+        case PixelStreamDynamicFileProtocol:
+            return (*(PixelStreamDynamicFile *)this == *(PixelStreamDynamicFile *)&that);
             break;
         case PixelStreamMjpegProtocol:
             return (*(PixelStreamMjpeg *)this == *(PixelStreamMjpeg *)&that);

--- a/packages/PixelStream/PixelStreamData.hh
+++ b/packages/PixelStream/PixelStreamData.hh
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-enum { PixelStreamUnknownProtocol, PixelStreamFileProtocol, PixelStreamMjpegProtocol, PixelStreamTcpProtocol, PixelStreamVsmProtocol };
+enum { PixelStreamUnknownProtocol, PixelStreamFileProtocol, PixelStreamMjpegProtocol, PixelStreamTcpProtocol, PixelStreamVsmProtocol, PixelStreamDynamicFileProtocol };
 
 class PixelStreamData
 {

--- a/packages/PixelStream/PixelStreamDynamicFile.cc
+++ b/packages/PixelStream/PixelStreamDynamicFile.cc
@@ -1,0 +1,152 @@
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+#include <sys/shm.h>
+#include "PixelStreamDynamicFile.hh"
+#include "basicutils/msg.hh"
+#include "basicutils/pathinfo.hh"
+
+// This is a safe size.  The shmget call will fail if it's too small or too large.  It only needs
+// to be large enough to house the elements of the PixelStreamShmem structure defined below.
+#define SHM_SIZE 1024
+
+PixelStreamDynamicFile::PixelStreamDynamicFile() : shm(0x0), buffercount(0)
+{
+    this->protocol = PixelStreamDynamicFileProtocol;
+}
+
+PixelStreamDynamicFile::~PixelStreamDynamicFile()
+{
+    if (this->shm) shmdt(this->shm);
+}
+
+bool PixelStreamDynamicFile::operator == (const PixelStreamDynamicFile &that)
+{
+    if (this->keyfilename == that.keyfilename) return true;
+    else return false;
+}
+
+bool PixelStreamDynamicFile::operator != (const PixelStreamDynamicFile &that)
+{
+    return !(*this == that);
+}
+
+int PixelStreamDynamicFile::genericInitialize(const std::string &filenamespec)
+{
+    if (filenamespec.empty()) return -1;
+    this->keyfilename = filenamespec;
+
+    // we are deferring retrieving the shared memory segment until the file
+    // we are sharing exists, this is required by the "ftok" function which
+    // we use to generate the shared memory key
+
+    return 0;
+}
+
+int PixelStreamDynamicFile::readerInitialize(const std::string &filenamespec)
+{
+    return genericInitialize(filenamespec);
+}
+
+int PixelStreamDynamicFile::writerInitialize(const std::string &filenamespec)
+{
+    if (genericInitialize(filenamespec)) return -1;
+
+    memset(this->shm, 0, SHM_SIZE);
+    return 0;
+}
+
+int PixelStreamDynamicFile::reader(void)
+{
+    int updated = 0;
+    uint32_t on = 1, off = 0;
+
+    // NOTE (JHH): Unlike the regular file protocol, here we are opening & closing the file every frame.
+    //             There does not seem to be a reliable way to ensure that 2 processes will see updates
+    //             to a file they both hold open. From a performance standpoint, the overhead is practically
+    //             neglible considering we are reading an uncompressed frame from disk!
+
+    connected = false;
+    if (this->shm)
+    {
+        connected = true;
+        if (!(this->shm->writing))
+        {
+            memcpy(&(this->shm->bufferrequested), &on, 4);
+            memcpy(&(this->shm->reading), &on, 4);
+            if (this->buffercount != this->shm->buffercount)
+            {
+                this->buffercount = this->shm->buffercount;
+                this->width = this->shm->width;
+                this->height = this->shm->height;
+                FILE *fpTemp = fopen(this->keyfilename.c_str(), "r");
+                rewind(fpTemp);
+                size_t nbytes = (size_t)(this->width * this->height * 3);
+                this->pixels = realloc(this->pixels, nbytes);
+                fread(this->pixels, 1, nbytes, fpTemp);
+                updated = 1;
+                fclose(fpTemp);
+            }
+            memcpy(&(this->shm->reading), &off, 4);
+        }
+    }
+    else
+    {
+
+        PathInfo mypath(this->keyfilename);
+        if(mypath.isValid()) // file exist
+        {
+            this->keyfilename = mypath.getFullPath();
+
+            key_t key= ftok(this->keyfilename.c_str(), 'R'); // generate a unique key for shared memory (in practice)
+
+            int shmid = shmget(key, SHM_SIZE, IPC_CREAT | 0777);
+            if (shmid < 0)
+            {
+                error_msg("Unable to get shared memory identifier: " << strerror(errno));
+                return 0;
+            }
+            this->shm = (PixelStreamDynamicFileShmem *)shmat(shmid, 0x0, 0);
+            if (!(this->shm))
+            {
+                error_msg("Unable to attach to shared memory: " << strerror(errno));
+                return 0;
+            }
+        }
+    }
+
+    return updated;
+}
+
+bool PixelStreamDynamicFile::writeRequested(void)
+{
+    if (this->pixels && this->shm->bufferrequested) return true;
+    else return false;
+}
+
+int PixelStreamDynamicFile::writer(void)
+{
+    uint32_t on = 1, off = 0;
+
+    if (!(this->pixels)) return 0;
+
+    if (!(this->shm->reading))
+    {
+            memcpy(&(this->shm->writing), &on, 4);
+            FILE *fpTemp = fopen(this->keyfilename.c_str(), "w");
+            rewind(fpTemp);
+            fwrite(this->pixels, 1, (size_t)(this->width * this->height * 3), fpTemp);
+            memcpy(&(this->shm->buffercount), &(this->buffercount), 8);
+            memcpy(&(this->shm->width), &(this->width), 4);
+            memcpy(&(this->shm->height), &(this->height), 4);
+            fflush(fpTemp);
+            fclose(fpTemp);
+            memcpy(&(this->shm->writing), &off, 4);
+            memcpy(&(this->shm->bufferrequested), &off, 4);
+    }
+    (this->buffercount)++;
+
+    return 1;
+}

--- a/packages/PixelStream/PixelStreamDynamicFile.hh
+++ b/packages/PixelStream/PixelStreamDynamicFile.hh
@@ -1,0 +1,42 @@
+#ifndef _PIXELSTREAMDYNAMICFILE_HH_
+#define _PIXELSTREAMDYNAMICFILE_HH_
+
+#include <string>
+#include <cstdio>
+#include <stdint.h>
+#include "PixelStreamData.hh"
+
+typedef struct
+{
+    uint32_t writing;
+    uint32_t reading;
+    uint64_t buffercount;
+    uint32_t width;
+    uint32_t height;
+    uint32_t bufferrequested;
+} PixelStreamDynamicFileShmem;
+
+class PixelStreamDynamicFile : public PixelStreamData
+{
+    public:
+    PixelStreamDynamicFile();
+        virtual ~PixelStreamDynamicFile();
+
+        bool operator == (const PixelStreamDynamicFile &);
+        bool operator != (const PixelStreamDynamicFile &);
+        int reader(void);
+        int writer(void);
+        bool writeRequested(void);
+
+        int readerInitialize(const std::string &);
+        int writerInitialize(const std::string &);
+
+    private:
+        int genericInitialize(const std::string &);
+
+        std::string keyfilename;
+        PixelStreamDynamicFileShmem *shm;
+        uint64_t buffercount;
+};
+
+#endif

--- a/primitives/pixelstream.cc
+++ b/primitives/pixelstream.cc
@@ -23,6 +23,7 @@ void dcPixelStream::setProtocol(const std::string &protocolstr, const std::strin
 {
     PixelStreamData *mypsd = 0x0;
     PixelStreamFile *psf;
+    PixelStreamDynamicFile *psdf;
     PixelStreamMjpeg *psm;
     PixelStreamTcp *pst;
     PixelStreamVsm *psv;
@@ -35,6 +36,7 @@ void dcPixelStream::setProtocol(const std::string &protocolstr, const std::strin
         if (CaseInsensitiveCompare(protocolstr, "MJPEG")) protocol = PixelStreamMjpegProtocol;
         if (CaseInsensitiveCompare(protocolstr, "TCP")) protocol = PixelStreamTcpProtocol;
         if (CaseInsensitiveCompare(protocolstr, "VSM")) protocol = PixelStreamVsmProtocol;
+        if (CaseInsensitiveCompare(protocolstr, "DFILE")) protocol = PixelStreamDynamicFileProtocol;
     }
 
     switch (protocol)
@@ -47,6 +49,15 @@ void dcPixelStream::setProtocol(const std::string &protocolstr, const std::strin
                 return;
             }
             mypsd = (PixelStreamData *)psf;
+            break;
+        case PixelStreamDynamicFileProtocol:
+            psdf = new PixelStreamDynamicFile;
+            if (psdf->readerInitialize(shmemkey))
+            {
+                delete psdf;
+                return;
+            }
+            mypsd = (PixelStreamDynamicFile *)psdf;
             break;
         case PixelStreamMjpegProtocol:
             psm = new PixelStreamMjpeg;


### PR DESCRIPTION
## Information
This PR addresses #43 and adds a new pixel stream protocol for local streaming. It works in a similar method to the existing file protocol but contains a handful of improvements. The previous protocol requires users to pass the generated shared memory key directly which depending on the specific setup could be overly restrictive by either having the user hardcode a value (which isn't guaranteed to be unique across systems or runs!) or in the case where the "writing" app generates the key the recommended way by using [ftok](https://man7.org/linux/man-pages/man3/ftok.3.html), they would need to manually supply the generated key. 

In the new protocol, both the client & server are expected to generate the key with ftok. ftok requires the path to a valid existing file, so here we've opted to make that file the same file we are attempting to share. This new protocol defers setting up shared memory until the file exists since dcapp may have been started before the server app. Once the file exists, the new protocol will setup the shared memory segment and begin streaming.

This new protocol uses the same shared memory struct & memory layout as the previous protocol so can used in its place with little refactoring.

## Usage
For usage, you set the protocol to "DFILE" and set SharedMemoryKey to the file that will be used by [ftok](https://man7.org/linux/man-pages/man3/ftok.3.html) which is used internally to generate the actual shared memory key. The file data is assumed to be 3 channels (RGB) of unsigned unnormalized 8-bit values.

Modified Screensaver example:
```xml
<?xml version="1.0"?>
<DCAPP>
    <Variable Type="String">CURRENT_TIME</Variable>
    <Variable Type="Decimal">POS_X</Variable>
    <Variable Type="Decimal">POS_Y</Variable>

    <DisplayLogic>logic/mylogic.so</DisplayLogic>

    <Window X="30" Y="30" Width="640" Height="480" ForceUpdate="0.01" ActiveDisplay="1">
        <Constant Name="BgColor">0 0 0</Constant>
        <Constant Name="FgColor">1 1 1</Constant>
        <Defaults>
            <String Size="42" Color="#FgColor"/>
        </Defaults>

        <Panel DisplayIndex="1" BackgroundColor="#BgColor" VirtualWidth="1600" VirtualHeight="1200">
            <String HorizontalAlign="Center" VerticalAlign="Middle">@CURRENT_TIME</String>

            <PixelStream X="@POS_X" Y="@POS_Y" Width="300" Height="300" Protocol="DFILE" SharedMemoryKey="../../../samples/screensaver/images/image.bin" TestPattern="images/nasa.tga"/>
        </Panel>

    </Window>
</DCAPP>
```

## Notes
Unlike the regular file protocol, here we are opening & closing the file every frame.
There does not seem to be a reliable way to ensure that 2 processes will see updates to a file they both hold open. From a performance standpoint, the overhead is practically negligible considering we are reading an uncompressed frame from disk!
