### PR TITLE
#215 Fullscreen support for window elements

### DIFF
--- a/apps/dcapp/node.h
+++ b/apps/dcapp/node.h
@@ -661,7 +661,7 @@ typedef struct __NodeWindow {
     _NodeIndex child;
     char      *title;
     _ValIndex  active_display;
-    _ValIndex  fullscreen;
+    bool       fullscreen;
 } _NodeWindow;
 
 typedef struct __Node {

--- a/apps/dcapp/node.h
+++ b/apps/dcapp/node.h
@@ -661,6 +661,7 @@ typedef struct __NodeWindow {
     _NodeIndex child;
     char      *title;
     _ValIndex  active_display;
+    _ValIndex  fullscreen;
 } _NodeWindow;
 
 typedef struct __Node {

--- a/apps/dcapp/xml.c
+++ b/apps/dcapp/xml.c
@@ -5413,7 +5413,8 @@ static _NodeIndex _process_xml_node_window(_AppData *app_data, xmlNodePtr xml_no
     // fullscreen mode
     xmlChar *raw_fullscreen = xmlGetProp(xml_node, BAD_CAST "Fullscreen");
     if (raw_fullscreen) {
-        dc_node.window.fullscreen = dc_app_create_and_register_typed_value_from_string(app_data->lookup, DC_VALUE_TYPE_BOOLEAN, (const char *)raw_fullscreen);
+
+        dc_node.window.fullscreen = xmlStrcmp(raw_fullscreen, BAD_CAST "true") == 0;
         xmlFree(raw_fullscreen);
     }
 
@@ -5917,8 +5918,7 @@ static void _init_app_data(_AppData *app_data, _Node *window_node) {
     window_desc.iYPos        = (int)window_node->window.init_position.y;
     _ext_windows->create(window_desc, &(app_data->pl_window));
 
-    const DcValue* fullscreen_val = dc_app_lookup_get_value(app_data->lookup, window_node->window.fullscreen);
-    if (fullscreen_val && fullscreen_val->value_boolean) {
+    if (window_node->window.fullscreen) {
         plFullScreenDesc fullscreen_desc = {};
         fullscreen_desc.tMode = PL_FULLSCREEN_MODE_EXCLUSIVE;
 

--- a/apps/dcapp/xml.c
+++ b/apps/dcapp/xml.c
@@ -5410,6 +5410,13 @@ static _NodeIndex _process_xml_node_window(_AppData *app_data, xmlNodePtr xml_no
         xmlFree(raw_active_display);
     }
 
+    // fullscreen mode
+    xmlChar *raw_fullscreen = xmlGetProp(xml_node, BAD_CAST "Fullscreen");
+    if (raw_fullscreen) {
+        dc_node.window.fullscreen = dc_app_create_and_register_typed_value_from_string(app_data->lookup, DC_VALUE_TYPE_BOOLEAN, (const char *)raw_fullscreen);
+        xmlFree(raw_fullscreen);
+    }
+
     // register node
     _NodeIndex node_index = _register_node(app_data, &dc_node);
 
@@ -5909,6 +5916,20 @@ static void _init_app_data(_AppData *app_data, _Node *window_node) {
     window_desc.iXPos        = (int)window_node->window.init_position.x;
     window_desc.iYPos        = (int)window_node->window.init_position.y;
     _ext_windows->create(window_desc, &(app_data->pl_window));
+
+    const DcValue* fullscreen_val = dc_app_lookup_get_value(app_data->lookup, window_node->window.fullscreen);
+    if (fullscreen_val && fullscreen_val->value_boolean) {
+        plFullScreenDesc fullscreen_desc = {};
+        fullscreen_desc.tMode = PL_FULLSCREEN_MODE_EXCLUSIVE;
+
+        const DcValue* active_display_val = dc_app_lookup_get_value(app_data->lookup, window_node->window.active_display);
+        if (active_display_val) {
+            fullscreen_desc.iMonitor = active_display_val->value_integer;
+        }
+
+        _ext_windows->set_fullscreen(app_data->pl_window, &fullscreen_desc);
+    }
+
     _ext_windows->show(app_data->pl_window);
 
     // initialize the starter API (handles alot of boilerplate)


### PR DESCRIPTION
Added support for fullscreen mode (https://github.com/nasa/dcapp/issues/215)

To enable fullscreen set `Fullscreen="true"` on any window element.
To specify which monitor fullscreen window will draw on use existing `ActiveDisplay="0"`, when no active display is set the primary monitor is used. If invalid active display id is passed the window will still spawn albeit  very small - this is handled by PL itself.




### Minimal test example:

```xml
<?xml version="1.0"?>
<DCAPP>
    <Constant Name="TextWhite">0.95 0.95 0.97</Constant>
    <Window Title="Welcome to DCAPP" X="30" Y="30" Width="1200" Height="800" Fullscreen="true">
        <Panel>
            <Text X="600" Y="680" Size="56" LocalAlignX="#_align_center_" FillColor="#TextWhite">Fullscreen Window Test</Text>
        </Panel>
    </Window>
</DCAPP>
```

Changes were tested on macOS  and Arch Linux.


*Note: Window creation logic remains inside the xml module to keep the scope of changes to minimum, dcapp.c feels like a better place for it in the future (after xml parsing is complete)*